### PR TITLE
Add convenience methods for fetching nodes deep in the tree

### DIFF
--- a/asdf-core/src/main/java/org/asdfformat/asdf/node/AsdfNode.java
+++ b/asdf-core/src/main/java/org/asdfformat/asdf/node/AsdfNode.java
@@ -106,6 +106,13 @@ public interface AsdfNode extends Iterable<AsdfNode> {
     boolean containsKey(AsdfNode key);
 
     /**
+     * Does the chain of MAPPING nodes contain the specified keys?
+     * @param keys mapping key for each successive node
+     * @return true if all keys are present
+     */
+    boolean containsKey(Object... keys);
+
+    /**
      * Get the size of this MAPPING or SEQUENCE node.
      * @return size
      */
@@ -140,6 +147,13 @@ public interface AsdfNode extends Iterable<AsdfNode> {
     AsdfNode get(AsdfNode key);
 
     /**
+     * Get a sequence value or mapping value as AsdfNode, indexed by a chain of keys.
+     * @param keys sequence indexes and mapping keys
+     * @return value
+     */
+    AsdfNode get(Object... keys);
+
+    /**
      * Get an optional mapping value as AsdfNode, indexed by String key.
      * @param key mapping key
      * @return value
@@ -166,6 +180,13 @@ public interface AsdfNode extends Iterable<AsdfNode> {
      * @return value
      */
     Optional<AsdfNode> getOptional(AsdfNode key);
+
+    /**
+     * Get an optional sequence value or mapping value as AsdfNode, indexed by a chain of keys.
+     * @param keys sequences indexes and mapping keys
+     * @return value
+     */
+    Optional<AsdfNode> getOptional(Object... keys);
 
     /**
      * Get a NUMBER mapping value as BigDecimal, indexed by String key.
@@ -196,6 +217,13 @@ public interface AsdfNode extends Iterable<AsdfNode> {
     BigDecimal getBigDecimal(AsdfNode key);
 
     /**
+     * Get a NUMBER sequence value or mapping value as BigDecimal, indexed by a chain of keys.
+     * @param keys sequence indexes and mapping keys
+     * @return value
+     */
+    BigDecimal getBigDecimal(Object... keys);
+
+    /**
      * Get a NUMBER mapping value as BigInteger, indexed by String key.
      * @param key mapping key
      * @return value
@@ -222,6 +250,13 @@ public interface AsdfNode extends Iterable<AsdfNode> {
      * @return value
      */
     BigInteger getBigInteger(AsdfNode key);
+
+    /**
+     * Get a NUMBER sequence value or mapping value as BigInteger, indexed by a chain of keys.
+     * @param keys sequence indexes and mapping keys
+     * @return value
+     */
+    BigInteger getBigInteger(Object... keys);
 
     /**
      * Get a BOOLEAN mapping value as boolean, indexed by String key.
@@ -252,6 +287,13 @@ public interface AsdfNode extends Iterable<AsdfNode> {
     boolean getBoolean(AsdfNode key);
 
     /**
+     * Get a BOOLEAN sequence value or mapping value as boolean, indexed by a chain of keys.
+     * @param keys sequence indexes and mapping keys
+     * @return value
+     */
+    boolean getBoolean(Object... keys);
+
+    /**
      * Get a NUMBER mapping value as byte, indexed by String key.
      * @param key mapping key
      * @return value
@@ -278,6 +320,13 @@ public interface AsdfNode extends Iterable<AsdfNode> {
      * @return value
      */
     byte getByte(AsdfNode key);
+
+    /**
+     * Get a NUMBER sequence value or mapping value as byte, indexed by a chain of keys.
+     * @param keys sequence indexes and mapping keys
+     * @return value
+     */
+    byte getByte(Object... keys);
 
     /**
      * Get a NUMBER mapping value as double, indexed by String key.
@@ -308,6 +357,13 @@ public interface AsdfNode extends Iterable<AsdfNode> {
     double getDouble(AsdfNode key);
 
     /**
+     * Get a NUMBER sequence value or mapping value as double, indexed by a chain of keys.
+     * @param keys sequence indexes and mapping keys
+     * @return value
+     */
+    double getDouble(Object... keys);
+
+    /**
      * Get a NUMBER mapping value as float, indexed by String key.
      * @param key mapping key
      * @return value
@@ -334,6 +390,13 @@ public interface AsdfNode extends Iterable<AsdfNode> {
      * @return value
      */
     float getFloat(AsdfNode key);
+
+    /**
+     * Get a NUMBER sequence value or mapping value as float, indexed by a chain of keys.
+     * @param keys sequence indexes and mapping keys
+     * @return value
+     */
+    float getFloat(Object... keys);
 
     /**
      * Get a TIMESTAMP mapping value as Instant, indexed by String key.
@@ -364,6 +427,13 @@ public interface AsdfNode extends Iterable<AsdfNode> {
     Instant getInstant(AsdfNode key);
 
     /**
+     * Get a TIMESTAMP sequence value or mapping value as Instant, indexed by a chain of keys.
+     * @param keys sequence indexes and mapping keys
+     * @return value
+     */
+    Instant getInstant(Object... keys);
+
+    /**
      * Get a NUMBER mapping value as int, indexed by String key.
      * @param key mapping key
      * @return value
@@ -392,12 +462,22 @@ public interface AsdfNode extends Iterable<AsdfNode> {
     int getInt(AsdfNode key);
 
     /**
+     * Get a NUMBER sequence value or mapping value as int, indexed by a chain of keys.
+     * @param keys sequence indexes and mapping keys
+     * @return value
+     */
+    int getInt(Object... keys);
+
+    /**
      * Get a SEQUENCE mapping value as List, indexed by String key.
      * @param key mapping key
      * @param elementClass element class
      * @return value
      * @param <T> List element
+     *
+     * @deprecated in favor of {@link #getList(Class, String)}
      */
+    @Deprecated
     <T> List<T> getList(String key, Class<T> elementClass);
 
     /**
@@ -406,7 +486,10 @@ public interface AsdfNode extends Iterable<AsdfNode> {
      * @param elementClass element class
      * @return value
      * @param <T> List element
+     *
+     * @deprecated in favor of {@link #getList(Class, long)}
      */
+    @Deprecated
     <T> List<T> getList(long key, Class<T> elementClass);
 
     /**
@@ -415,7 +498,10 @@ public interface AsdfNode extends Iterable<AsdfNode> {
      * @param elementClass element class
      * @return value
      * @param <T> List element
+     *
+     * @deprecated in favor of {@link #getList(Class, boolean)}
      */
+    @Deprecated
     <T> List<T> getList(boolean key, Class<T> elementClass);
 
     /**
@@ -424,8 +510,56 @@ public interface AsdfNode extends Iterable<AsdfNode> {
      * @param elementClass element class
      * @return value
      * @param <T> List element
+     *
+     * @deprecated in favor of {@link #getList(Class, AsdfNode)}
      */
+    @Deprecated
     <T> List<T> getList(AsdfNode key, Class<T> elementClass);
+
+    /**
+     * Get a SEQUENCE mapping value as List, indexed by String key.
+     * @param elementClass element class
+     * @param key mapping key
+     * @return value
+     * @param <T> List element
+     */
+    <T> List<T> getList(Class<T> elementClass, String key);
+
+    /**
+     * Get a SEQUENCE sequence value or mapping value as List, indexed by long key.
+     * @param key sequence index or mapping key
+     * @param elementClass element class
+     * @return value
+     * @param <T> List element
+     */
+    <T> List<T> getList(Class<T> elementClass, long key);
+
+    /**
+     * Get a SEQUENCE mapping value as List, indexed by boolean key.
+     * @param key mapping key
+     * @param elementClass element class
+     * @return value
+     * @param <T> List element
+     */
+    <T> List<T> getList(Class<T> elementClass, boolean key);
+
+    /**
+     * Get a SEQUENCE sequence value or mapping value as List, indexed by AsdfNode key.
+     * @param key sequence index or mapping key
+     * @param elementClass element class
+     * @return value
+     * @param <T> List element
+     */
+    <T> List<T> getList(Class<T> elementClass, AsdfNode key);
+
+    /**
+     * Get a SEQUENCE sequence value or mapping value as List, indexed by a chain of keys.
+     * @param elementClass element class
+     * @param keys sequence indexes and mapping keys
+     * @return value
+     * @param <T> List element
+     */
+    <T> List<T> getList(Class<T> elementClass, Object... keys);
 
     /**
      * Get a NUMBER mapping value as long, indexed by String key.
@@ -456,6 +590,13 @@ public interface AsdfNode extends Iterable<AsdfNode> {
     long getLong(AsdfNode key);
 
     /**
+     * Get a NUMBER sequence value or mapping value as long, indexed by a chain of keys.
+     * @param keys sequence indexes and mapping keys
+     * @return value
+     */
+    long getLong(Object... keys);
+
+    /**
      * Get a NUMBER mapping value as a Number, indexed by String key.
      * @param key mapping key
      * @return value
@@ -484,6 +625,13 @@ public interface AsdfNode extends Iterable<AsdfNode> {
     Number getNumber(AsdfNode key);
 
     /**
+     * Get a NUMBER sequence value or mapping value as Number, indexed by a chain of keys.
+     * @param keys sequence indexes and mapping keys
+     * @return value
+     */
+    Number getNumber(Object... keys);
+
+    /**
      * Get a MAPPING mapping value as Map, indexed by String key.
      * @param key mapping key
      * @param keyClass key class
@@ -491,7 +639,10 @@ public interface AsdfNode extends Iterable<AsdfNode> {
      * @return value
      * @param <K> Map key
      * @param <V> Map value
+     *
+     * @deprecated in favor of {@link #getMap(Class, Class, String)}
      */
+    @Deprecated
     <K, V> Map<K, V> getMap(String key, Class<K> keyClass, Class<V> valueClass);
 
     /**
@@ -502,7 +653,10 @@ public interface AsdfNode extends Iterable<AsdfNode> {
      * @return value
      * @param <K> Map key
      * @param <V> Map value
+     *
+     * @deprecated in favor of {@link #getMap(Class, Class, long)}
      */
+    @Deprecated
     <K, V> Map<K, V> getMap(long key, Class<K> keyClass, Class<V> valueClass);
 
     /**
@@ -513,7 +667,10 @@ public interface AsdfNode extends Iterable<AsdfNode> {
      * @return value
      * @param <K> Map key
      * @param <V> Map value
+     *
+     * @deprecated in favor of {@link #getMap(Class, Class, boolean)}
      */
+    @Deprecated
     <K, V> Map<K, V> getMap(boolean key, Class<K> keyClass, Class<V> valueClass);
 
     /**
@@ -524,8 +681,66 @@ public interface AsdfNode extends Iterable<AsdfNode> {
      * @return value
      * @param <K> Map key
      * @param <V> Map value
+     *
+     * @deprecated in favor of {@link #getMap(Class, Class, AsdfNode)}
      */
+    @Deprecated
     <K, V> Map<K, V> getMap(AsdfNode key, Class<K> keyClass, Class<V> valueClass);
+
+    /**
+     * Get a MAPPING mapping value as Map, indexed by String key.
+     * @param keyClass key class
+     * @param valueClass value class
+     * @param key mapping key
+     * @return value
+     * @param <K> Map key
+     * @param <V> Map value
+     */
+    <K, V> Map<K, V> getMap(Class<K> keyClass, Class<V> valueClass, String key);
+
+    /**
+     * Get a MAPPING sequence value or mapping value as Map, indexed by long key.
+     * @param keyClass key class
+     * @param valueClass value class
+     * @param key sequence index or mapping key
+     * @return value
+     * @param <K> Map key
+     * @param <V> Map value
+     */
+    <K, V> Map<K, V> getMap(Class<K> keyClass, Class<V> valueClass, long key);
+
+    /**
+     * Get a MAPPING mapping value as Map, indexed by String key.
+     * @param keyClass key class
+     * @param valueClass value class
+     * @param key mapping key
+     * @return value
+     * @param <K> Map key
+     * @param <V> Map value
+     */
+    <K, V> Map<K, V> getMap(Class<K> keyClass, Class<V> valueClass, boolean key);
+
+    /**
+     * Get a MAPPING mapping value as Map, indexed by AsdfNode key.
+     * @param keyClass key class
+     * @param valueClass value class
+     * @param key sequence index or mapping key
+     * @return value
+     * @param <K> Map key
+     * @param <V> Map value
+     */
+    <K, V> Map<K, V> getMap(Class<K> keyClass, Class<V> valueClass, AsdfNode key);
+
+    /**
+     * Get a MAPPING sequence value or mapping value as Map, indexed by a chain of keys.
+     * @param keyClass key class
+     * @param valueClass value class
+     * @param keys sequence indexes and mapping keys
+     * @return value
+     * @param <K> Map key
+     * @param <V> Map value     *
+     */
+    <K, V> Map<K, V> getMap(Class<K> keyClass, Class<V> valueClass, Object... keys);
 
     /**
      * Get a NDARRAY mapping value, indexed by String key.
@@ -556,6 +771,13 @@ public interface AsdfNode extends Iterable<AsdfNode> {
     NdArray<?> getNdArray(AsdfNode key);
 
     /**
+     * Get a NDARRAY sequence value or mapping value, indexed by a chain of keys.
+     * @param keys sequence indexes and mapping keys
+     * @return value
+     */
+    NdArray<?> getNdArray(Object... keys);
+
+    /**
      * Get a NUMBER mapping value as short, indexed by String key.
      * @param key mapping key
      * @return value
@@ -584,6 +806,13 @@ public interface AsdfNode extends Iterable<AsdfNode> {
     short getShort(AsdfNode key);
 
     /**
+     * Get a NUMBER sequence value or mapping value as short, indexed by a chain of keys.
+     * @param keys sequence indexes and mapping keys
+     * @return value
+     */
+    short getShort(Object... keys);
+
+    /**
      * Get a STRING mapping value, indexed by String key.
      * @param key mapping key
      * @return value
@@ -610,6 +839,13 @@ public interface AsdfNode extends Iterable<AsdfNode> {
      * @return value
      */
     String getString(AsdfNode key);
+
+    /**
+     * Get a STRING sequence value or mapping value, indexed by a chain of keys.
+     * @param keys sequence indexes and mapping keys
+     * @return value
+     */
+    String getString(Object... keys);
 
     /**
      * Get this NUMBER node's value as BigDecimal.

--- a/asdf-core/src/main/java/org/asdfformat/asdf/node/impl/AsdfNodeBase.java
+++ b/asdf-core/src/main/java/org/asdfformat/asdf/node/impl/AsdfNodeBase.java
@@ -7,6 +7,7 @@ import org.asdfformat.asdf.node.AsdfNodeType;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -76,6 +77,18 @@ public abstract class AsdfNodeBase implements AsdfNode {
     }
 
     @Override
+    public boolean containsKey(final Object... keys) {
+        if (keys.length == 0) {
+            return true;
+        }
+
+        final AsdfNode currentKey = constructKeyNode(keys[0]);
+
+        return getOptional(currentKey).map(node -> node.containsKey(Arrays.copyOfRange(keys, 1, keys.length)))
+                .orElse(false);
+    }
+
+    @Override
     public int size() {
         return 0;
     }
@@ -98,6 +111,17 @@ public abstract class AsdfNodeBase implements AsdfNode {
     @Override
     public AsdfNode get(final AsdfNode key) {
         throw new IllegalStateException(makeGetErrorMessage("AsdfNode"));
+    }
+
+    @Override
+    public AsdfNode get(final Object... keys) {
+        if (keys.length == 0) {
+            return this;
+        }
+
+        final AsdfNode currentKey = constructKeyNode(keys[0]);
+
+        return get(currentKey).get(Arrays.copyOfRange(keys, 1, keys.length));
     }
 
     @Override
@@ -157,6 +181,17 @@ public abstract class AsdfNodeBase implements AsdfNode {
     }
 
     @Override
+    public Optional<AsdfNode> getOptional(final Object... keys) {
+        if (keys.length == 0) {
+            return Optional.of(this);
+        }
+
+        final AsdfNode currentKey = constructKeyNode(keys[0]);
+
+        return getOptional(currentKey).flatMap(node -> node.getOptional(Arrays.copyOfRange(keys, 1, keys.length)));
+    }
+
+    @Override
     public BigDecimal getBigDecimal(final String key) {
         return get(key).asBigDecimal();
     }
@@ -174,6 +209,11 @@ public abstract class AsdfNodeBase implements AsdfNode {
     @Override
     public BigDecimal getBigDecimal(final AsdfNode key) {
         return get(key).asBigDecimal();
+    }
+
+    @Override
+    public BigDecimal getBigDecimal(final Object... keys) {
+        return get(keys).asBigDecimal();
     }
 
     @Override
@@ -197,6 +237,11 @@ public abstract class AsdfNodeBase implements AsdfNode {
     }
 
     @Override
+    public BigInteger getBigInteger(final Object... keys) {
+        return get(keys).asBigInteger();
+    }
+
+    @Override
     public boolean getBoolean(final String key) {
         return get(key).asBoolean();
     }
@@ -214,6 +259,11 @@ public abstract class AsdfNodeBase implements AsdfNode {
     @Override
     public boolean getBoolean(final AsdfNode key) {
         return get(key).asBoolean();
+    }
+
+    @Override
+    public boolean getBoolean(final Object... keys) {
+        return get(keys).asBoolean();
     }
 
     @Override
@@ -237,6 +287,11 @@ public abstract class AsdfNodeBase implements AsdfNode {
     }
 
     @Override
+    public byte getByte(final Object... keys) {
+        return get(keys).asByte();
+    }
+
+    @Override
     public double getDouble(final String key) {
         return get(key).asDouble();
     }
@@ -254,6 +309,11 @@ public abstract class AsdfNodeBase implements AsdfNode {
     @Override
     public double getDouble(final AsdfNode key) {
         return get(key).asDouble();
+    }
+
+    @Override
+    public double getDouble(final Object... keys) {
+        return get(keys).asDouble();
     }
 
     @Override
@@ -277,6 +337,11 @@ public abstract class AsdfNodeBase implements AsdfNode {
     }
 
     @Override
+    public float getFloat(final Object... keys) {
+        return get(keys).asFloat();
+    }
+
+    @Override
     public Instant getInstant(final String key) {
         return get(key).asInstant();
     }
@@ -294,6 +359,11 @@ public abstract class AsdfNodeBase implements AsdfNode {
     @Override
     public Instant getInstant(final AsdfNode key) {
         return get(key).asInstant();
+    }
+
+    @Override
+    public Instant getInstant(final Object... keys) {
+        return get(keys).asInstant();
     }
 
     @Override
@@ -317,6 +387,11 @@ public abstract class AsdfNodeBase implements AsdfNode {
     }
 
     @Override
+    public int getInt(final Object... keys) {
+        return get(keys).asInt();
+    }
+
+    @Override
     public <T> List<T> getList(final String key, final Class<T> elementClass) {
         return get(key).asList(elementClass);
     }
@@ -334,6 +409,31 @@ public abstract class AsdfNodeBase implements AsdfNode {
     @Override
     public <T> List<T> getList(final AsdfNode key, final Class<T> elementClass) {
         return get(key).asList(elementClass);
+    }
+
+    @Override
+    public <T> List<T> getList(final Class<T> elementClass, final String key) {
+        return get(key).asList(elementClass);
+    }
+
+    @Override
+    public <T> List<T> getList(final Class<T> elementClass, final long key) {
+        return get(key).asList(elementClass);
+    }
+
+    @Override
+    public <T> List<T> getList(final Class<T> elementClass, final boolean key) {
+        return get(key).asList(elementClass);
+    }
+
+    @Override
+    public <T> List<T> getList(final Class<T> elementClass, final AsdfNode key) {
+        return get(key).asList(elementClass);
+    }
+
+    @Override
+    public <T> List<T> getList(final Class<T> elementClass, final Object... keys) {
+        return get(keys).asList(elementClass);
     }
 
     @Override
@@ -357,6 +457,11 @@ public abstract class AsdfNodeBase implements AsdfNode {
     }
 
     @Override
+    public long getLong(final Object... keys) {
+        return get(keys).asLong();
+    }
+
+    @Override
     public Number getNumber(final String key) {
         return get(key).asNumber();
     }
@@ -374,6 +479,11 @@ public abstract class AsdfNodeBase implements AsdfNode {
     @Override
     public Number getNumber(final AsdfNode key) {
         return get(key).asNumber();
+    }
+
+    @Override
+    public Number getNumber(final Object... keys) {
+        return get(keys).asNumber();
     }
 
     @Override
@@ -397,6 +507,31 @@ public abstract class AsdfNodeBase implements AsdfNode {
     }
 
     @Override
+    public <K, V> Map<K, V> getMap(final Class<K> keyClass, final Class<V> valueClass, final String key) {
+        return get(key).asMap(keyClass, valueClass);
+    }
+
+    @Override
+    public <K, V> Map<K, V> getMap(final Class<K> keyClass, final Class<V> valueClass, final long key) {
+        return get(key).asMap(keyClass, valueClass);
+    }
+
+    @Override
+    public <K, V> Map<K, V> getMap(final Class<K> keyClass, final Class<V> valueClass, final boolean key) {
+        return get(key).asMap(keyClass, valueClass);
+    }
+
+    @Override
+    public <K, V> Map<K, V> getMap(final Class<K> keyClass, final Class<V> valueClass, final AsdfNode key) {
+        return get(key).asMap(keyClass, valueClass);
+    }
+
+    @Override
+    public <K, V> Map<K, V> getMap(final Class<K> keyClass, final Class<V> valueClass, final Object... keys) {
+        return get(keys).asMap(keyClass, valueClass);
+    }
+
+    @Override
     public NdArray<?> getNdArray(final String key) {
         return get(key).asNdArray();
     }
@@ -414,6 +549,11 @@ public abstract class AsdfNodeBase implements AsdfNode {
     @Override
     public NdArray<?> getNdArray(final AsdfNode key) {
         return get(key).asNdArray();
+    }
+
+    @Override
+    public NdArray<?> getNdArray(final Object... keys) {
+        return get(keys).asNdArray();
     }
 
     @Override
@@ -437,6 +577,11 @@ public abstract class AsdfNodeBase implements AsdfNode {
     }
 
     @Override
+    public short getShort(final Object... keys) {
+        return get(keys).asShort();
+    }
+
+    @Override
     public String getString(final String key) {
         return get(key).asString();
     }
@@ -454,6 +599,11 @@ public abstract class AsdfNodeBase implements AsdfNode {
     @Override
     public String getString(final AsdfNode key) {
         return get(key).asString();
+    }
+
+    @Override
+    public String getString(final Object... keys) {
+        return get(keys).asString();
     }
 
     @Override
@@ -551,5 +701,19 @@ public abstract class AsdfNodeBase implements AsdfNode {
 
     protected String makeAsErrorMessage(final String asType) {
         return String.format("%s node cannot be represented as %s", getNodeType(), asType);
+    }
+
+    protected AsdfNode constructKeyNode(final Object key) {
+        if (key instanceof String) {
+            return StringAsdfNode.of((String)key);
+        } else if (key instanceof AsdfNode) {
+            return (AsdfNode)key;
+        } else if (key instanceof Number) {
+            return NumberAsdfNode.of((Number)key);
+        } else if (key instanceof Boolean) {
+            return BooleanAsdfNode.of((Boolean)key);
+        } else {
+            throw new IllegalArgumentException("Unhandled key class: " + key.getClass().getSimpleName());
+        }
     }
 }

--- a/asdf-core/src/main/java/org/asdfformat/asdf/testing/ReferenceFileUtils.java
+++ b/asdf-core/src/main/java/org/asdfformat/asdf/testing/ReferenceFileUtils.java
@@ -10,10 +10,13 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+
+import static org.junit.Assume.assumeTrue;
 
 public class ReferenceFileUtils {
     private static final String PYTHON_PATH = System.getenv("ASDF_JAVA_TESTS_PYTHON_PATH");
@@ -59,6 +62,13 @@ public class ReferenceFileUtils {
             file.deleteOnExit();
             final Path path = file.toPath();
 
+            assumeTrue(
+                    "ASDF_JAVA_TESTS_PYTHON_PATH missing or unset",
+                    Optional.ofNullable(PYTHON_PATH)
+                            .map(p -> p.isEmpty() ? null : p)
+                            .map(p -> Files.exists(Paths.get(p)))
+                            .orElse(false)
+            );
             final Process process = new ProcessBuilder(PYTHON_PATH, TEST_FILE_GENERATOR_PY_PATH.toString(), "--version", asdfStandardVersion.toString()).start();
             try (final OutputStream outputStream = process.getOutputStream()) {
                 IOUtils.transferTo(scriptInputStream, outputStream);

--- a/asdf-core/src/test/java/org/asdfformat/asdf/node/BooleanAsdfNodeTest.java
+++ b/asdf-core/src/test/java/org/asdfformat/asdf/node/BooleanAsdfNodeTest.java
@@ -13,6 +13,7 @@ import org.yaml.snakeyaml.nodes.Tag;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -141,6 +142,8 @@ public class BooleanAsdfNodeTest {
         assertFalse(node.containsKey(1L));
         assertFalse(node.containsKey(false));
         assertFalse(node.containsKey(node));
+        assertFalse(node.containsKey("foo", 1L, false, node));
+        assertTrue(node.containsKey());
 
         assertEquals(0, node.size());
 
@@ -150,81 +153,113 @@ public class BooleanAsdfNodeTest {
         assertThrows(IllegalStateException.class, () -> node.get(1L));
         assertThrows(IllegalStateException.class, () -> node.get(false));
         assertThrows(IllegalStateException.class, () -> node.get(node));
+        assertThrows(IllegalStateException.class, () -> node.get("foo", 1L, false, node));
+        assertSame(node, node.get());
 
         assertThrows(IllegalStateException.class, () -> node.getBigDecimal("foo"));
         assertThrows(IllegalStateException.class, () -> node.getBigDecimal(1L));
         assertThrows(IllegalStateException.class, () -> node.getBigDecimal(false));
         assertThrows(IllegalStateException.class, () -> node.getBigDecimal(node));
+        assertThrows(IllegalStateException.class, () -> node.getBigDecimal("foo", 1L, false, node));
+        assertThrows(IllegalStateException.class, node::getBigDecimal);
 
         assertThrows(IllegalStateException.class, () -> node.getBigInteger("foo"));
         assertThrows(IllegalStateException.class, () -> node.getBigInteger(1L));
         assertThrows(IllegalStateException.class, () -> node.getBigInteger(false));
         assertThrows(IllegalStateException.class, () -> node.getBigInteger(node));
+        assertThrows(IllegalStateException.class, () -> node.getBigInteger("foo", 1L, false, node));
+        assertThrows(IllegalStateException.class, node::getBigInteger);
 
         assertThrows(IllegalStateException.class, () -> node.getBoolean("foo"));
         assertThrows(IllegalStateException.class, () -> node.getBoolean(1L));
         assertThrows(IllegalStateException.class, () -> node.getBoolean(false));
         assertThrows(IllegalStateException.class, () -> node.getBoolean(node));
+        assertThrows(IllegalStateException.class, () -> node.getBoolean("foo", 1L, false, node));
+        assertTrue(node.getBoolean());
 
         assertThrows(IllegalStateException.class, () -> node.getByte("foo"));
         assertThrows(IllegalStateException.class, () -> node.getByte(1L));
         assertThrows(IllegalStateException.class, () -> node.getByte(false));
         assertThrows(IllegalStateException.class, () -> node.getByte(node));
+        assertThrows(IllegalStateException.class, () -> node.getByte("foo", 1L, false, node));
+        assertThrows(IllegalStateException.class, node::getByte);
 
         assertThrows(IllegalStateException.class, () -> node.getDouble("foo"));
         assertThrows(IllegalStateException.class, () -> node.getDouble(1L));
         assertThrows(IllegalStateException.class, () -> node.getDouble(false));
         assertThrows(IllegalStateException.class, () -> node.getDouble(node));
+        assertThrows(IllegalStateException.class, () -> node.getDouble("foo", 1L, false, node));
+        assertThrows(IllegalStateException.class, node::getDouble);
 
         assertThrows(IllegalStateException.class, () -> node.getFloat("foo"));
         assertThrows(IllegalStateException.class, () -> node.getFloat(1L));
         assertThrows(IllegalStateException.class, () -> node.getFloat(false));
         assertThrows(IllegalStateException.class, () -> node.getFloat(node));
+        assertThrows(IllegalStateException.class, () -> node.getFloat("foo", 1L, false, node));
+        assertThrows(IllegalStateException.class, node::getFloat);
 
         assertThrows(IllegalStateException.class, () -> node.getInstant("foo"));
         assertThrows(IllegalStateException.class, () -> node.getInstant(1L));
         assertThrows(IllegalStateException.class, () -> node.getInstant(false));
         assertThrows(IllegalStateException.class, () -> node.getInstant(node));
+        assertThrows(IllegalStateException.class, () -> node.getInstant("foo", 1L, false, node));
+        assertThrows(IllegalStateException.class, node::getInstant);
 
         assertThrows(IllegalStateException.class, () -> node.getInt("foo"));
         assertThrows(IllegalStateException.class, () -> node.getInt(1L));
         assertThrows(IllegalStateException.class, () -> node.getInt(false));
         assertThrows(IllegalStateException.class, () -> node.getInt(node));
+        assertThrows(IllegalStateException.class, () -> node.getInt("foo", 1L, false, node));
+        assertThrows(IllegalStateException.class, node::getInt);
 
-        assertThrows(IllegalStateException.class, () -> node.getList("foo", String.class));
-        assertThrows(IllegalStateException.class, () -> node.getList(1L, String.class));
-        assertThrows(IllegalStateException.class, () -> node.getList(false, String.class));
-        assertThrows(IllegalStateException.class, () -> node.getList(node, String.class));
+        assertThrows(IllegalStateException.class, () -> node.getList(String.class, "foo"));
+        assertThrows(IllegalStateException.class, () -> node.getList(String.class, 1L));
+        assertThrows(IllegalStateException.class, () -> node.getList(String.class, false));
+        assertThrows(IllegalStateException.class, () -> node.getList(String.class, node));
+        assertThrows(IllegalStateException.class, () -> node.getList(String.class, "foo", 1L, false, node));
+        assertThrows(IllegalStateException.class, () -> node.getList(String.class));
 
         assertThrows(IllegalStateException.class, () -> node.getLong("foo"));
         assertThrows(IllegalStateException.class, () -> node.getLong(1L));
         assertThrows(IllegalStateException.class, () -> node.getLong(false));
         assertThrows(IllegalStateException.class, () -> node.getLong(node));
+        assertThrows(IllegalStateException.class, () -> node.getLong("foo", 1L, false, node));
+        assertThrows(IllegalStateException.class, node::getLong);
 
         assertThrows(IllegalStateException.class, () -> node.getNumber("foo"));
         assertThrows(IllegalStateException.class, () -> node.getNumber(1L));
         assertThrows(IllegalStateException.class, () -> node.getNumber(false));
         assertThrows(IllegalStateException.class, () -> node.getNumber(node));
+        assertThrows(IllegalStateException.class, () -> node.getNumber("foo", 1L, false, node));
+        assertThrows(IllegalStateException.class, node::getNumber);
 
-        assertThrows(IllegalStateException.class, () -> node.getMap("foo", String.class, String.class));
-        assertThrows(IllegalStateException.class, () -> node.getMap(1L, String.class, String.class));
-        assertThrows(IllegalStateException.class, () -> node.getMap(false, String.class, String.class));
-        assertThrows(IllegalStateException.class, () -> node.getMap(node, String.class, String.class));
+        assertThrows(IllegalStateException.class, () -> node.getMap(String.class, String.class, "foo"));
+        assertThrows(IllegalStateException.class, () -> node.getMap(String.class, String.class, 1L));
+        assertThrows(IllegalStateException.class, () -> node.getMap(String.class, String.class, false));
+        assertThrows(IllegalStateException.class, () -> node.getMap(String.class, String.class, node));
+        assertThrows(IllegalStateException.class, () -> node.getMap(String.class, String.class, "foo", 1L, false, node));
+        assertThrows(IllegalStateException.class, () -> node.getMap(String.class, String.class));
 
         assertThrows(IllegalStateException.class, () -> node.getNdArray("foo"));
         assertThrows(IllegalStateException.class, () -> node.getNdArray(1L));
         assertThrows(IllegalStateException.class, () -> node.getNdArray(false));
         assertThrows(IllegalStateException.class, () -> node.getNdArray(node));
+        assertThrows(IllegalStateException.class, () -> node.getNdArray("foo", 1L, false, node));
+        assertThrows(IllegalStateException.class, node::getNdArray);
 
         assertThrows(IllegalStateException.class, () -> node.getShort("foo"));
         assertThrows(IllegalStateException.class, () -> node.getShort(1L));
         assertThrows(IllegalStateException.class, () -> node.getShort(false));
         assertThrows(IllegalStateException.class, () -> node.getShort(node));
+        assertThrows(IllegalStateException.class, () -> node.getShort("foo", 1L, false, node));
+        assertThrows(IllegalStateException.class, node::getShort);
 
         assertThrows(IllegalStateException.class, () -> node.getString("foo"));
         assertThrows(IllegalStateException.class, () -> node.getString(1L));
         assertThrows(IllegalStateException.class, () -> node.getString(false));
         assertThrows(IllegalStateException.class, () -> node.getString(node));
+        assertThrows(IllegalStateException.class, () -> node.getString("foo", 1L, false, node));
+        assertThrows(IllegalStateException.class, node::getString);
 
         assertThrows(IllegalStateException.class, node::asBigDecimal);
         assertThrows(IllegalStateException.class, node::asBigInteger);

--- a/asdf-core/src/test/java/org/asdfformat/asdf/node/NullAsdfNodeTest.java
+++ b/asdf-core/src/test/java/org/asdfformat/asdf/node/NullAsdfNodeTest.java
@@ -10,6 +10,7 @@ import org.yaml.snakeyaml.nodes.Tag;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -62,6 +63,8 @@ public class NullAsdfNodeTest {
         assertFalse(node.containsKey(1L));
         assertFalse(node.containsKey(false));
         assertFalse(node.containsKey(node));
+        assertFalse(node.containsKey("foo", 1L, false, node));
+        assertTrue(node.containsKey());
 
         assertEquals(0, node.size());
 
@@ -71,81 +74,113 @@ public class NullAsdfNodeTest {
         assertThrows(IllegalStateException.class, () -> node.get(1L));
         assertThrows(IllegalStateException.class, () -> node.get(false));
         assertThrows(IllegalStateException.class, () -> node.get(node));
+        assertThrows(IllegalStateException.class, () -> node.get("foo", 1L, false, node));
+        assertSame(node, node.get());
 
         assertThrows(IllegalStateException.class, () -> node.getBigDecimal("foo"));
         assertThrows(IllegalStateException.class, () -> node.getBigDecimal(1L));
         assertThrows(IllegalStateException.class, () -> node.getBigDecimal(false));
         assertThrows(IllegalStateException.class, () -> node.getBigDecimal(node));
+        assertThrows(IllegalStateException.class, () -> node.getBigDecimal("foo", 1L, false, node));
+        assertThrows(IllegalStateException.class, node::getBigDecimal);
 
         assertThrows(IllegalStateException.class, () -> node.getBigInteger("foo"));
         assertThrows(IllegalStateException.class, () -> node.getBigInteger(1L));
         assertThrows(IllegalStateException.class, () -> node.getBigInteger(false));
         assertThrows(IllegalStateException.class, () -> node.getBigInteger(node));
+        assertThrows(IllegalStateException.class, () -> node.getBigInteger("foo", 1L, false, node));
+        assertThrows(IllegalStateException.class, node::getBigInteger);
 
         assertThrows(IllegalStateException.class, () -> node.getBoolean("foo"));
         assertThrows(IllegalStateException.class, () -> node.getBoolean(1L));
         assertThrows(IllegalStateException.class, () -> node.getBoolean(false));
         assertThrows(IllegalStateException.class, () -> node.getBoolean(node));
+        assertThrows(IllegalStateException.class, () -> node.getBoolean("foo", 1L, false, node));
+        assertThrows(IllegalStateException.class, node::getBoolean);
 
         assertThrows(IllegalStateException.class, () -> node.getByte("foo"));
         assertThrows(IllegalStateException.class, () -> node.getByte(1L));
         assertThrows(IllegalStateException.class, () -> node.getByte(false));
         assertThrows(IllegalStateException.class, () -> node.getByte(node));
+        assertThrows(IllegalStateException.class, () -> node.getByte("foo", 1L, false, node));
+        assertThrows(IllegalStateException.class, node::getByte);
 
         assertThrows(IllegalStateException.class, () -> node.getDouble("foo"));
         assertThrows(IllegalStateException.class, () -> node.getDouble(1L));
         assertThrows(IllegalStateException.class, () -> node.getDouble(false));
         assertThrows(IllegalStateException.class, () -> node.getDouble(node));
+        assertThrows(IllegalStateException.class, () -> node.getDouble("foo", 1L, false, node));
+        assertThrows(IllegalStateException.class, node::getDouble);
 
         assertThrows(IllegalStateException.class, () -> node.getFloat("foo"));
         assertThrows(IllegalStateException.class, () -> node.getFloat(1L));
         assertThrows(IllegalStateException.class, () -> node.getFloat(false));
         assertThrows(IllegalStateException.class, () -> node.getFloat(node));
+        assertThrows(IllegalStateException.class, () -> node.getFloat("foo", 1L, false, node));
+        assertThrows(IllegalStateException.class, node::getFloat);
 
         assertThrows(IllegalStateException.class, () -> node.getInstant("foo"));
         assertThrows(IllegalStateException.class, () -> node.getInstant(1L));
         assertThrows(IllegalStateException.class, () -> node.getInstant(false));
         assertThrows(IllegalStateException.class, () -> node.getInstant(node));
+        assertThrows(IllegalStateException.class, () -> node.getInstant("foo", 1L, false, node));
+        assertThrows(IllegalStateException.class, node::getInstant);
 
         assertThrows(IllegalStateException.class, () -> node.getInt("foo"));
         assertThrows(IllegalStateException.class, () -> node.getInt(1L));
         assertThrows(IllegalStateException.class, () -> node.getInt(false));
         assertThrows(IllegalStateException.class, () -> node.getInt(node));
+        assertThrows(IllegalStateException.class, () -> node.getInt("foo", 1L, false, node));
+        assertThrows(IllegalStateException.class, node::getInt);
 
-        assertThrows(IllegalStateException.class, () -> node.getList("foo", String.class));
-        assertThrows(IllegalStateException.class, () -> node.getList(1L, String.class));
-        assertThrows(IllegalStateException.class, () -> node.getList(false, String.class));
-        assertThrows(IllegalStateException.class, () -> node.getList(node, String.class));
+        assertThrows(IllegalStateException.class, () -> node.getList(String.class, "foo"));
+        assertThrows(IllegalStateException.class, () -> node.getList(String.class, 1L));
+        assertThrows(IllegalStateException.class, () -> node.getList(String.class, false));
+        assertThrows(IllegalStateException.class, () -> node.getList(String.class, node));
+        assertThrows(IllegalStateException.class, () -> node.getList(String.class, "foo", 1L, false, node));
+        assertThrows(IllegalStateException.class, () -> node.getList(String.class));
 
         assertThrows(IllegalStateException.class, () -> node.getLong("foo"));
         assertThrows(IllegalStateException.class, () -> node.getLong(1L));
         assertThrows(IllegalStateException.class, () -> node.getLong(false));
         assertThrows(IllegalStateException.class, () -> node.getLong(node));
+        assertThrows(IllegalStateException.class, () -> node.getLong("foo", 1L, false, node));
+        assertThrows(IllegalStateException.class, node::getLong);
 
         assertThrows(IllegalStateException.class, () -> node.getNumber("foo"));
         assertThrows(IllegalStateException.class, () -> node.getNumber(1L));
         assertThrows(IllegalStateException.class, () -> node.getNumber(false));
         assertThrows(IllegalStateException.class, () -> node.getNumber(node));
+        assertThrows(IllegalStateException.class, () -> node.getNumber("foo", 1L, false, node));
+        assertThrows(IllegalStateException.class, node::getNumber);
 
-        assertThrows(IllegalStateException.class, () -> node.getMap("foo", String.class, String.class));
-        assertThrows(IllegalStateException.class, () -> node.getMap(1L, String.class, String.class));
-        assertThrows(IllegalStateException.class, () -> node.getMap(false, String.class, String.class));
-        assertThrows(IllegalStateException.class, () -> node.getMap(node, String.class, String.class));
+        assertThrows(IllegalStateException.class, () -> node.getMap(String.class, String.class, "foo"));
+        assertThrows(IllegalStateException.class, () -> node.getMap(String.class, String.class, 1L));
+        assertThrows(IllegalStateException.class, () -> node.getMap(String.class, String.class, false));
+        assertThrows(IllegalStateException.class, () -> node.getMap(String.class, String.class, node));
+        assertThrows(IllegalStateException.class, () -> node.getMap(String.class, String.class, "foo", 1L, false, node));
+        assertThrows(IllegalStateException.class, () -> node.getMap(String.class, String.class));
 
         assertThrows(IllegalStateException.class, () -> node.getNdArray("foo"));
         assertThrows(IllegalStateException.class, () -> node.getNdArray(1L));
         assertThrows(IllegalStateException.class, () -> node.getNdArray(false));
         assertThrows(IllegalStateException.class, () -> node.getNdArray(node));
+        assertThrows(IllegalStateException.class, () -> node.getNdArray("foo", 1L, false, node));
+        assertThrows(IllegalStateException.class, node::getNdArray);
 
         assertThrows(IllegalStateException.class, () -> node.getShort("foo"));
         assertThrows(IllegalStateException.class, () -> node.getShort(1L));
         assertThrows(IllegalStateException.class, () -> node.getShort(false));
         assertThrows(IllegalStateException.class, () -> node.getShort(node));
+        assertThrows(IllegalStateException.class, () -> node.getShort("foo", 1L, false, node));
+        assertThrows(IllegalStateException.class, node::getShort);
 
         assertThrows(IllegalStateException.class, () -> node.getString("foo"));
         assertThrows(IllegalStateException.class, () -> node.getString(1L));
         assertThrows(IllegalStateException.class, () -> node.getString(false));
         assertThrows(IllegalStateException.class, () -> node.getString(node));
+        assertThrows(IllegalStateException.class, () -> node.getString("foo", 1L, false, node));
+        assertThrows(IllegalStateException.class, node::getString);
 
         assertThrows(IllegalStateException.class, node::asBigDecimal);
         assertThrows(IllegalStateException.class, node::asBigInteger);

--- a/asdf-core/src/test/java/org/asdfformat/asdf/node/StringAsdfNodeTest.java
+++ b/asdf-core/src/test/java/org/asdfformat/asdf/node/StringAsdfNodeTest.java
@@ -11,6 +11,7 @@ import org.yaml.snakeyaml.nodes.Tag;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -55,6 +56,7 @@ public class StringAsdfNodeTest {
 
     @Nested
     class ConstructionFromSnakeYamlNode {
+        @Test
         void testBasic() {
             final ScalarNode snakeYamlNode = new ScalarNode(Tag.STR, "foo", null, null, DumperOptions.ScalarStyle.LITERAL);
             final StringAsdfNode asdfNode = StringAsdfNode.of(snakeYamlNode);
@@ -105,6 +107,8 @@ public class StringAsdfNodeTest {
         assertFalse(node.containsKey(1L));
         assertFalse(node.containsKey(false));
         assertFalse(node.containsKey(node));
+        assertFalse(node.containsKey("foo", 1L, false, node));
+        assertTrue(node.containsKey());
 
         assertEquals(0, node.size());
 
@@ -114,81 +118,113 @@ public class StringAsdfNodeTest {
         assertThrows(IllegalStateException.class, () -> node.get(1L));
         assertThrows(IllegalStateException.class, () -> node.get(false));
         assertThrows(IllegalStateException.class, () -> node.get(node));
+        assertThrows(IllegalStateException.class, () -> node.get("foo", 1L, false, node));
+        assertSame(node, node.get());
 
         assertThrows(IllegalStateException.class, () -> node.getBigDecimal("foo"));
         assertThrows(IllegalStateException.class, () -> node.getBigDecimal(1L));
         assertThrows(IllegalStateException.class, () -> node.getBigDecimal(false));
         assertThrows(IllegalStateException.class, () -> node.getBigDecimal(node));
+        assertThrows(IllegalStateException.class, () -> node.getBigDecimal("foo", 1L, false, node));
+        assertThrows(IllegalStateException.class, node::getBigDecimal);
 
         assertThrows(IllegalStateException.class, () -> node.getBigInteger("foo"));
         assertThrows(IllegalStateException.class, () -> node.getBigInteger(1L));
         assertThrows(IllegalStateException.class, () -> node.getBigInteger(false));
         assertThrows(IllegalStateException.class, () -> node.getBigInteger(node));
+        assertThrows(IllegalStateException.class, () -> node.getBigInteger("foo", 1L, false, node));
+        assertThrows(IllegalStateException.class, node::getBigInteger);
 
         assertThrows(IllegalStateException.class, () -> node.getBoolean("foo"));
         assertThrows(IllegalStateException.class, () -> node.getBoolean(1L));
         assertThrows(IllegalStateException.class, () -> node.getBoolean(false));
         assertThrows(IllegalStateException.class, () -> node.getBoolean(node));
+        assertThrows(IllegalStateException.class, () -> node.getBoolean("foo", 1L, false, node));
+        assertThrows(IllegalStateException.class, node::getBoolean);
 
         assertThrows(IllegalStateException.class, () -> node.getByte("foo"));
         assertThrows(IllegalStateException.class, () -> node.getByte(1L));
         assertThrows(IllegalStateException.class, () -> node.getByte(false));
         assertThrows(IllegalStateException.class, () -> node.getByte(node));
+        assertThrows(IllegalStateException.class, () -> node.getByte("foo", 1L, false, node));
+        assertThrows(IllegalStateException.class, node::getByte);
 
         assertThrows(IllegalStateException.class, () -> node.getDouble("foo"));
         assertThrows(IllegalStateException.class, () -> node.getDouble(1L));
         assertThrows(IllegalStateException.class, () -> node.getDouble(false));
         assertThrows(IllegalStateException.class, () -> node.getDouble(node));
+        assertThrows(IllegalStateException.class, () -> node.getDouble("foo", 1L, false, node));
+        assertThrows(IllegalStateException.class, node::getDouble);
 
         assertThrows(IllegalStateException.class, () -> node.getFloat("foo"));
         assertThrows(IllegalStateException.class, () -> node.getFloat(1L));
         assertThrows(IllegalStateException.class, () -> node.getFloat(false));
         assertThrows(IllegalStateException.class, () -> node.getFloat(node));
+        assertThrows(IllegalStateException.class, () -> node.getFloat("foo", 1L, false, node));
+        assertThrows(IllegalStateException.class, node::getFloat);
 
         assertThrows(IllegalStateException.class, () -> node.getInstant("foo"));
         assertThrows(IllegalStateException.class, () -> node.getInstant(1L));
         assertThrows(IllegalStateException.class, () -> node.getInstant(false));
         assertThrows(IllegalStateException.class, () -> node.getInstant(node));
+        assertThrows(IllegalStateException.class, () -> node.getInstant("foo", 1L, false, node));
+        assertThrows(IllegalStateException.class, node::getInstant);
 
         assertThrows(IllegalStateException.class, () -> node.getInt("foo"));
         assertThrows(IllegalStateException.class, () -> node.getInt(1L));
         assertThrows(IllegalStateException.class, () -> node.getInt(false));
         assertThrows(IllegalStateException.class, () -> node.getInt(node));
+        assertThrows(IllegalStateException.class, () -> node.getInt("foo", 1L, false, node));
+        assertThrows(IllegalStateException.class, node::getInt);
 
-        assertThrows(IllegalStateException.class, () -> node.getList("foo", String.class));
-        assertThrows(IllegalStateException.class, () -> node.getList(1L, String.class));
-        assertThrows(IllegalStateException.class, () -> node.getList(false, String.class));
-        assertThrows(IllegalStateException.class, () -> node.getList(node, String.class));
+        assertThrows(IllegalStateException.class, () -> node.getList(String.class, "foo"));
+        assertThrows(IllegalStateException.class, () -> node.getList(String.class, 1L));
+        assertThrows(IllegalStateException.class, () -> node.getList(String.class, false));
+        assertThrows(IllegalStateException.class, () -> node.getList(String.class, node));
+        assertThrows(IllegalStateException.class, () -> node.getList(String.class, "foo", 1L, false, node));
+        assertThrows(IllegalStateException.class, () -> node.getList(String.class));
 
         assertThrows(IllegalStateException.class, () -> node.getLong("foo"));
         assertThrows(IllegalStateException.class, () -> node.getLong(1L));
         assertThrows(IllegalStateException.class, () -> node.getLong(false));
         assertThrows(IllegalStateException.class, () -> node.getLong(node));
+        assertThrows(IllegalStateException.class, () -> node.getLong("foo", 1L, false, node));
+        assertThrows(IllegalStateException.class, node::getLong);
 
         assertThrows(IllegalStateException.class, () -> node.getNumber("foo"));
         assertThrows(IllegalStateException.class, () -> node.getNumber(1L));
         assertThrows(IllegalStateException.class, () -> node.getNumber(false));
         assertThrows(IllegalStateException.class, () -> node.getNumber(node));
+        assertThrows(IllegalStateException.class, () -> node.getNumber("foo", 1L, false, node));
+        assertThrows(IllegalStateException.class, node::getNumber);
 
-        assertThrows(IllegalStateException.class, () -> node.getMap("foo", String.class, String.class));
-        assertThrows(IllegalStateException.class, () -> node.getMap(1L, String.class, String.class));
-        assertThrows(IllegalStateException.class, () -> node.getMap(false, String.class, String.class));
-        assertThrows(IllegalStateException.class, () -> node.getMap(node, String.class, String.class));
+        assertThrows(IllegalStateException.class, () -> node.getMap(String.class, String.class, "foo"));
+        assertThrows(IllegalStateException.class, () -> node.getMap(String.class, String.class, 1L));
+        assertThrows(IllegalStateException.class, () -> node.getMap(String.class, String.class, false));
+        assertThrows(IllegalStateException.class, () -> node.getMap(String.class, String.class, node));
+        assertThrows(IllegalStateException.class, () -> node.getMap(String.class, String.class, "foo", 1L, false, node));
+        assertThrows(IllegalStateException.class, () -> node.getMap(String.class, String.class));
 
         assertThrows(IllegalStateException.class, () -> node.getNdArray("foo"));
         assertThrows(IllegalStateException.class, () -> node.getNdArray(1L));
         assertThrows(IllegalStateException.class, () -> node.getNdArray(false));
         assertThrows(IllegalStateException.class, () -> node.getNdArray(node));
+        assertThrows(IllegalStateException.class, () -> node.getNdArray("foo", 1L, false, node));
+        assertThrows(IllegalStateException.class, node::getNdArray);
 
         assertThrows(IllegalStateException.class, () -> node.getShort("foo"));
         assertThrows(IllegalStateException.class, () -> node.getShort(1L));
         assertThrows(IllegalStateException.class, () -> node.getShort(false));
         assertThrows(IllegalStateException.class, () -> node.getShort(node));
+        assertThrows(IllegalStateException.class, () -> node.getShort("foo", 1L, false, node));
+        assertThrows(IllegalStateException.class, node::getShort);
 
         assertThrows(IllegalStateException.class, () -> node.getString("foo"));
         assertThrows(IllegalStateException.class, () -> node.getString(1L));
         assertThrows(IllegalStateException.class, () -> node.getString(false));
         assertThrows(IllegalStateException.class, () -> node.getString(node));
+        assertThrows(IllegalStateException.class, () -> node.getString("foo", 1L, false, node));
+        assertEquals("foo", node.getString());
 
         assertThrows(IllegalStateException.class, node::asBigDecimal);
         assertThrows(IllegalStateException.class, node::asBigInteger);

--- a/asdf-core/src/test/java/org/asdfformat/asdf/node/TimestampAsdfNodeTest.java
+++ b/asdf-core/src/test/java/org/asdfformat/asdf/node/TimestampAsdfNodeTest.java
@@ -14,6 +14,7 @@ import java.time.temporal.ChronoUnit;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -63,6 +64,7 @@ public class TimestampAsdfNodeTest {
         final String value = "2001-12-15T02:59:43.100Z";
         final Instant instant = Instant.parse(value);
 
+        @Test
         void testBasic() {
             final ScalarNode snakeYamlNode = new ScalarNode(Tag.TIMESTAMP, value, null, null, DumperOptions.ScalarStyle.LITERAL);
             final TimestampAsdfNode asdfNode = TimestampAsdfNode.of(snakeYamlNode, instant);
@@ -98,7 +100,8 @@ public class TimestampAsdfNodeTest {
 
     @Test
     void testBaseMethods() {
-        final TimestampAsdfNode node = TimestampAsdfNode.of(Instant.now());
+        final Instant instant = Instant.now();
+        final TimestampAsdfNode node = TimestampAsdfNode.of(instant);
 
         assertFalse(node.isBoolean());
         assertFalse(node.isMapping());
@@ -113,6 +116,8 @@ public class TimestampAsdfNodeTest {
         assertFalse(node.containsKey(1L));
         assertFalse(node.containsKey(false));
         assertFalse(node.containsKey(node));
+        assertFalse(node.containsKey("foo", 1L, false, node));
+        assertTrue(node.containsKey());
 
         assertEquals(0, node.size());
 
@@ -122,81 +127,113 @@ public class TimestampAsdfNodeTest {
         assertThrows(IllegalStateException.class, () -> node.get(1L));
         assertThrows(IllegalStateException.class, () -> node.get(false));
         assertThrows(IllegalStateException.class, () -> node.get(node));
+        assertThrows(IllegalStateException.class, () -> node.get("foo", 1L, false, node));
+        assertSame(node, node.get());
 
         assertThrows(IllegalStateException.class, () -> node.getBigDecimal("foo"));
         assertThrows(IllegalStateException.class, () -> node.getBigDecimal(1L));
         assertThrows(IllegalStateException.class, () -> node.getBigDecimal(false));
         assertThrows(IllegalStateException.class, () -> node.getBigDecimal(node));
+        assertThrows(IllegalStateException.class, () -> node.getBigDecimal("foo", 1L, false, node));
+        assertThrows(IllegalStateException.class, node::getBigDecimal);
 
         assertThrows(IllegalStateException.class, () -> node.getBigInteger("foo"));
         assertThrows(IllegalStateException.class, () -> node.getBigInteger(1L));
         assertThrows(IllegalStateException.class, () -> node.getBigInteger(false));
         assertThrows(IllegalStateException.class, () -> node.getBigInteger(node));
+        assertThrows(IllegalStateException.class, () -> node.getBigInteger("foo", 1L, false, node));
+        assertThrows(IllegalStateException.class, node::getBigInteger);
 
         assertThrows(IllegalStateException.class, () -> node.getBoolean("foo"));
         assertThrows(IllegalStateException.class, () -> node.getBoolean(1L));
         assertThrows(IllegalStateException.class, () -> node.getBoolean(false));
         assertThrows(IllegalStateException.class, () -> node.getBoolean(node));
+        assertThrows(IllegalStateException.class, () -> node.getBoolean("foo", 1L, false, node));
+        assertThrows(IllegalStateException.class, node::getBoolean);
 
         assertThrows(IllegalStateException.class, () -> node.getByte("foo"));
         assertThrows(IllegalStateException.class, () -> node.getByte(1L));
         assertThrows(IllegalStateException.class, () -> node.getByte(false));
         assertThrows(IllegalStateException.class, () -> node.getByte(node));
+        assertThrows(IllegalStateException.class, () -> node.getByte("foo", 1L, false, node));
+        assertThrows(IllegalStateException.class, node::getByte);
 
         assertThrows(IllegalStateException.class, () -> node.getDouble("foo"));
         assertThrows(IllegalStateException.class, () -> node.getDouble(1L));
         assertThrows(IllegalStateException.class, () -> node.getDouble(false));
         assertThrows(IllegalStateException.class, () -> node.getDouble(node));
+        assertThrows(IllegalStateException.class, () -> node.getDouble("foo", 1L, false, node));
+        assertThrows(IllegalStateException.class, node::getDouble);
 
         assertThrows(IllegalStateException.class, () -> node.getFloat("foo"));
         assertThrows(IllegalStateException.class, () -> node.getFloat(1L));
         assertThrows(IllegalStateException.class, () -> node.getFloat(false));
         assertThrows(IllegalStateException.class, () -> node.getFloat(node));
+        assertThrows(IllegalStateException.class, () -> node.getFloat("foo", 1L, false, node));
+        assertThrows(IllegalStateException.class, node::getFloat);
 
         assertThrows(IllegalStateException.class, () -> node.getInstant("foo"));
         assertThrows(IllegalStateException.class, () -> node.getInstant(1L));
         assertThrows(IllegalStateException.class, () -> node.getInstant(false));
         assertThrows(IllegalStateException.class, () -> node.getInstant(node));
+        assertThrows(IllegalStateException.class, () -> node.getInstant("foo", 1L, false, node));
+        assertEquals(instant, node.getInstant());
 
         assertThrows(IllegalStateException.class, () -> node.getInt("foo"));
         assertThrows(IllegalStateException.class, () -> node.getInt(1L));
         assertThrows(IllegalStateException.class, () -> node.getInt(false));
         assertThrows(IllegalStateException.class, () -> node.getInt(node));
+        assertThrows(IllegalStateException.class, () -> node.getInt("foo", 1L, false, node));
+        assertThrows(IllegalStateException.class, node::getInt);
 
-        assertThrows(IllegalStateException.class, () -> node.getList("foo", String.class));
-        assertThrows(IllegalStateException.class, () -> node.getList(1L, String.class));
-        assertThrows(IllegalStateException.class, () -> node.getList(false, String.class));
-        assertThrows(IllegalStateException.class, () -> node.getList(node, String.class));
+        assertThrows(IllegalStateException.class, () -> node.getList(String.class, "foo"));
+        assertThrows(IllegalStateException.class, () -> node.getList(String.class, 1L));
+        assertThrows(IllegalStateException.class, () -> node.getList(String.class, false));
+        assertThrows(IllegalStateException.class, () -> node.getList(String.class, node));
+        assertThrows(IllegalStateException.class, () -> node.getList(String.class, "foo", 1L, false, node));
+        assertThrows(IllegalStateException.class, () -> node.getList(String.class));
 
         assertThrows(IllegalStateException.class, () -> node.getLong("foo"));
         assertThrows(IllegalStateException.class, () -> node.getLong(1L));
         assertThrows(IllegalStateException.class, () -> node.getLong(false));
         assertThrows(IllegalStateException.class, () -> node.getLong(node));
+        assertThrows(IllegalStateException.class, () -> node.getLong("foo", 1L, false, node));
+        assertThrows(IllegalStateException.class, node::getLong);
 
         assertThrows(IllegalStateException.class, () -> node.getNumber("foo"));
         assertThrows(IllegalStateException.class, () -> node.getNumber(1L));
         assertThrows(IllegalStateException.class, () -> node.getNumber(false));
         assertThrows(IllegalStateException.class, () -> node.getNumber(node));
+        assertThrows(IllegalStateException.class, () -> node.getNumber("foo", 1L, false, node));
+        assertThrows(IllegalStateException.class, node::getNumber);
 
-        assertThrows(IllegalStateException.class, () -> node.getMap("foo", String.class, String.class));
-        assertThrows(IllegalStateException.class, () -> node.getMap(1L, String.class, String.class));
-        assertThrows(IllegalStateException.class, () -> node.getMap(false, String.class, String.class));
-        assertThrows(IllegalStateException.class, () -> node.getMap(node, String.class, String.class));
+        assertThrows(IllegalStateException.class, () -> node.getMap(String.class, String.class, "foo"));
+        assertThrows(IllegalStateException.class, () -> node.getMap(String.class, String.class, 1L));
+        assertThrows(IllegalStateException.class, () -> node.getMap(String.class, String.class, false));
+        assertThrows(IllegalStateException.class, () -> node.getMap(String.class, String.class, node));
+        assertThrows(IllegalStateException.class, () -> node.getMap(String.class, String.class, "foo", 1L, false, node));
+        assertThrows(IllegalStateException.class, () -> node.getMap(String.class, String.class));
 
         assertThrows(IllegalStateException.class, () -> node.getNdArray("foo"));
         assertThrows(IllegalStateException.class, () -> node.getNdArray(1L));
         assertThrows(IllegalStateException.class, () -> node.getNdArray(false));
         assertThrows(IllegalStateException.class, () -> node.getNdArray(node));
+        assertThrows(IllegalStateException.class, () -> node.getNdArray("foo", 1L, false, node));
+        assertThrows(IllegalStateException.class, node::getNdArray);
 
         assertThrows(IllegalStateException.class, () -> node.getShort("foo"));
         assertThrows(IllegalStateException.class, () -> node.getShort(1L));
         assertThrows(IllegalStateException.class, () -> node.getShort(false));
         assertThrows(IllegalStateException.class, () -> node.getShort(node));
+        assertThrows(IllegalStateException.class, () -> node.getShort("foo", 1L, false, node));
+        assertThrows(IllegalStateException.class, node::getShort);
 
         assertThrows(IllegalStateException.class, () -> node.getString("foo"));
         assertThrows(IllegalStateException.class, () -> node.getString(1L));
         assertThrows(IllegalStateException.class, () -> node.getString(false));
         assertThrows(IllegalStateException.class, () -> node.getString(node));
+        assertThrows(IllegalStateException.class, () -> node.getString("foo", 1L, false, node));
+        assertThrows(IllegalStateException.class, node::getString);
 
         assertThrows(IllegalStateException.class, node::asBigDecimal);
         assertThrows(IllegalStateException.class, node::asBigInteger);

--- a/asdf-core/src/test/java/org/asdfformat/asdf/node/VarargMethodTest.java
+++ b/asdf-core/src/test/java/org/asdfformat/asdf/node/VarargMethodTest.java
@@ -1,0 +1,274 @@
+package org.asdfformat.asdf.node;
+
+import org.asdfformat.asdf.node.impl.BooleanAsdfNode;
+import org.asdfformat.asdf.node.impl.MappingAsdfNode;
+import org.asdfformat.asdf.node.impl.NdArrayAsdfNode;
+import org.asdfformat.asdf.node.impl.NumberAsdfNode;
+import org.asdfformat.asdf.node.impl.SequenceAsdfNode;
+import org.asdfformat.asdf.node.impl.StringAsdfNode;
+import org.asdfformat.asdf.node.impl.TimestampAsdfNode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.nodes.MappingNode;
+import org.yaml.snakeyaml.nodes.SequenceNode;
+import org.yaml.snakeyaml.nodes.Tag;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class VarargMethodTest {
+    private AsdfNode leafNode;
+    private AsdfNode sequenceNode;
+    private AsdfNode rootNode;
+
+    @BeforeEach
+    void beforeEach() {
+        final Map<AsdfNode, AsdfNode> leafMap = new HashMap<>();
+        leafMap.put(StringAsdfNode.of("string"), StringAsdfNode.of("string key value"));
+        leafMap.put(BooleanAsdfNode.of(true), StringAsdfNode.of("boolean key value"));
+        leafMap.put(NumberAsdfNode.of(1), StringAsdfNode.of("number key value"));
+
+        leafMap.put(StringAsdfNode.of("big decimal"), NumberAsdfNode.of(BigDecimal.TEN));
+        leafMap.put(StringAsdfNode.of("boolean"), BooleanAsdfNode.of(true));
+        leafMap.put(StringAsdfNode.of("byte"), NumberAsdfNode.of(0x1F));
+        leafMap.put(StringAsdfNode.of("double"), NumberAsdfNode.of(Double.MAX_VALUE));
+        leafMap.put(StringAsdfNode.of("float"), NumberAsdfNode.of(Float.MAX_VALUE));
+        leafMap.put(StringAsdfNode.of("instant"), TimestampAsdfNode.of(Instant.EPOCH));
+        leafMap.put(StringAsdfNode.of("int"), NumberAsdfNode.of(Integer.MAX_VALUE));
+
+        leafMap.put(StringAsdfNode.of("list"), SequenceAsdfNode.of(
+                new SequenceNode(Tag.SEQ, Collections.emptyList(), DumperOptions.FlowStyle.FLOW),
+                Stream.of("a", "b", "c").map(StringAsdfNode::of).collect(Collectors.toList())
+        ));
+
+        leafMap.put(StringAsdfNode.of("long"), NumberAsdfNode.of(Long.MAX_VALUE));
+
+        leafMap.put(StringAsdfNode.of("map"), MappingAsdfNode.of(
+                new MappingNode(Tag.MAP, Collections.emptyList(), DumperOptions.FlowStyle.FLOW),
+                Stream.of("a", "b", "c").collect(Collectors.toMap(
+                        StringAsdfNode::of,
+                        v -> StringAsdfNode.of(v + " value")
+                ))
+        ));
+
+        final NdArrayAsdfNode ndArrayAsdfNode = mock();
+        when(ndArrayAsdfNode.get()).thenReturn(ndArrayAsdfNode);
+        leafMap.put(StringAsdfNode.of("ndarray"), ndArrayAsdfNode);
+
+        leafMap.put(StringAsdfNode.of("number"), NumberAsdfNode.of(14));
+        leafMap.put(StringAsdfNode.of("short"), NumberAsdfNode.of(Short.MAX_VALUE));
+
+        leafNode = MappingAsdfNode.of(
+                new MappingNode(Tag.MAP, Collections.emptyList(), DumperOptions.FlowStyle.FLOW),
+                leafMap
+        );
+
+        sequenceNode = SequenceAsdfNode.of(
+                new SequenceNode(Tag.SEQ, Collections.emptyList(), DumperOptions.FlowStyle.FLOW),
+                Stream.of(leafNode).collect(Collectors.toList())
+        );
+
+        final Map<AsdfNode, AsdfNode> rootMap = new HashMap<>();
+        rootMap.put(StringAsdfNode.of("sequence"), sequenceNode);
+
+        rootNode = MappingAsdfNode.of(
+                new MappingNode(Tag.MAP, Collections.emptyList(), DumperOptions.FlowStyle.FLOW),
+                rootMap
+        );
+    }
+
+    @Nested
+    class ContainsKey {
+        @Test
+        void testNoArgs() {
+            assertTrue(rootNode.containsKey());
+        }
+
+        @Test
+        void testFirstLevel() {
+            assertTrue(rootNode.containsKey("sequence"));
+            assertFalse(rootNode.containsKey("missing"));
+        }
+
+        @Test
+        void testSecondLevel() {
+            assertTrue(rootNode.containsKey("sequence", 0));
+            assertFalse(rootNode.containsKey("sequence", 1));
+        }
+
+        @Test
+        void testThirdLevel() {
+            assertTrue(rootNode.containsKey("sequence", 0, "string"));
+            assertFalse(rootNode.containsKey("sequence", 0, "missing"));
+        }
+    }
+
+    @Nested
+    class Get {
+        @Test
+        void testNoArgs() {
+            assertSame(rootNode, rootNode.get());
+        }
+
+        @Test
+        void testFirstLevel() {
+            assertSame(sequenceNode, rootNode.get("sequence"));
+            assertThrows(IllegalArgumentException.class, () -> rootNode.get("missing"));
+        }
+
+        @Test
+        void testSecondLevel() {
+            assertSame(leafNode, rootNode.get("sequence", 0));
+            assertThrows(IndexOutOfBoundsException.class, () -> rootNode.get("sequence", 1));
+        }
+
+        @Test
+        void testThirdLevel() {
+            assertSame(leafNode.get("string"), rootNode.get("sequence", 0, "string"));
+            assertThrows(IllegalArgumentException.class, () -> rootNode.get("sequence", 0, "missing"));
+        }
+    }
+
+    @Nested
+    class GetOptional {
+        @Test
+        void testNoArgs() {
+            assertEquals(Optional.of(rootNode), rootNode.getOptional());
+        }
+
+        @Test
+        void testFirstLevel() {
+            assertEquals(Optional.of(sequenceNode), rootNode.getOptional("sequence"));
+            assertFalse(rootNode.getOptional("missing").isPresent());
+        }
+
+        @Test
+        void testSecondLevel() {
+            assertEquals(Optional.of(leafNode), rootNode.getOptional("sequence", 0));
+            assertFalse(rootNode.getOptional("sequence", 1).isPresent());
+        }
+
+        @Test
+        void testThirdLevel() {
+            assertEquals(Optional.of(leafNode.get("string")), rootNode.getOptional("sequence", 0, "string"));
+            assertFalse(rootNode.getOptional("sequence", 0, "missing").isPresent());
+        }
+    }
+
+    @Nested
+    class GetTyped {
+        @Test
+        void testGetBigDecimal() {
+            assertEquals(leafNode.getBigDecimal("big decimal"), rootNode.getBigDecimal("sequence", 0, "big decimal"));
+        }
+
+        @Test
+        void testGetBoolean() {
+            assertEquals(leafNode.getBoolean("boolean"), rootNode.getBoolean("sequence", 0, "boolean"));
+        }
+
+        @Test
+        void testGetByte() {
+            assertEquals(leafNode.getByte("byte"), rootNode.getByte("sequence", 0, "byte"));
+        }
+
+        @Test
+        void testGetDouble() {
+            assertEquals(leafNode.getDouble("double"), rootNode.getDouble("sequence", 0, "double"));
+        }
+
+        @Test
+        void testGetFloat() {
+            assertEquals(leafNode.getFloat("float"), rootNode.getFloat("sequence", 0, "float"));
+        }
+
+        @Test
+        void testGetInstant() {
+            assertEquals(leafNode.getInstant("instant"), rootNode.getInstant("sequence", 0, "instant"));
+        }
+
+        @Test
+        void testGetInt() {
+            assertEquals(leafNode.getInt("int"), rootNode.getInt("sequence", 0, "int"));
+        }
+
+        @Test
+        void testGetList() {
+            assertEquals(leafNode.getList(String.class, "list"), rootNode.getList(String.class, "sequence", 0, "list"));
+        }
+
+        @Test
+        void testGetLong() {
+            assertEquals(leafNode.getLong("long"), rootNode.getLong("sequence", 0, "long"));
+        }
+
+        @Test
+        void testGetMap() {
+            assertEquals(leafNode.getMap(String.class, String.class, "map"), rootNode.getMap(String.class, String.class, "sequence", 0, "map"));
+        }
+
+        @Test
+        void testGetNdArray() {
+            assertEquals(leafNode.getNdArray("ndarray"), rootNode.getNdArray("sequence", 0, "ndarray"));
+        }
+
+        @Test
+        void testGetNumber() {
+            assertEquals(leafNode.getNumber("number"), rootNode.getNumber("sequence", 0, "number"));
+        }
+
+        @Test
+        void testGetShort() {
+            assertEquals(leafNode.getShort("short"), rootNode.getShort("sequence", 0, "short"));
+        }
+
+        @Test
+        void testGetString() {
+            assertEquals(leafNode.getString("string"), rootNode.getString("sequence", 0, "string"));
+        }
+    }
+
+    @Nested
+    class KeyTypes {
+        @Test
+        void testStringKey() {
+            assertEquals(leafNode.getString("string"), rootNode.getString("sequence", 0, "string"));
+        }
+
+        @Test
+        void testBooleanKey() {
+            assertEquals(leafNode.getString(true), rootNode.getString("sequence", 0, true));
+        }
+
+        @Test
+        void testNumberKey() {
+            assertEquals(leafNode.getString(1), rootNode.getString("sequence", 0, 1));
+        }
+
+        @Test
+        void testAsdfNodeKey() {
+            assertEquals(leafNode.getString(NumberAsdfNode.of(1)), rootNode.getString("sequence", 0, NumberAsdfNode.of(1)));
+        }
+
+        @Test
+        void testInvalidKeyType() {
+            assertThrows(IllegalArgumentException.class, () -> leafNode.getString(new Object()));
+        }
+    }
+}


### PR DESCRIPTION
This adds convenience methods for fetching nodes deep in the tree.  For example, until now it has been necessary to chain method calls to get to a node at path `root.child.grandchild`:

```java
node.get("root").get("child").get("grandchild")
```

This PR adds vararg overloads of the get methods so that this can be accomplished in a single method call:

```java
node.get("root", "child", "grandchild")
```

Since varargs can't be followed by other arguments, I'm also deprecating the old getList and getMap methods and introducing new methods that place the list and map types at the beginning of the argument list.

Thanks Trey for the idea!